### PR TITLE
Add define guard to `NOMINMAX` macro definition

### DIFF
--- a/fmtlog-inl.h
+++ b/fmtlog-inl.h
@@ -28,7 +28,9 @@ SOFTWARE.
 #include <ios>
 
 #ifdef _WIN32
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #include <windows.h>
 #include <processthreadsapi.h>
 #else


### PR DESCRIPTION
We're using fmtlog as a header-only library on Windows. Because we have `NOMINMAX` already defined somewhere else, this macro gives the compiler warning [C4005 (macro redefinition)](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4005) . 

This can easily be fixed by adding some define guards. I guess `NOMINMAX` is a pretty commonly used define, so IMO it makes sense to add this guard.