### PR TITLE
Improve startPollingThread declaration.

### DIFF
--- a/fmtlog.h
+++ b/fmtlog.h
@@ -160,9 +160,9 @@ public:
   // return true if passed log level is not lower than current log level
   static inline bool checkLogLevel(LogLevel logLevel) noexcept;
 
-  // Run a polling thread in the background with a polling interval
+  // Run a polling thread in the background with a polling interval (in milliseconds)
   // Note that user must not call poll() himself when the thread is running
-  static void startPollingThread(int64_t pollInterval = 1000000) noexcept;
+  static void startPollingThread(int64_t msPollInterval = 1000000) noexcept;
 
   // Stop the polling thread
   static void stopPollingThread() noexcept;


### PR DESCRIPTION
To make things more obvious I added the 'ms' prefix to the `pollInterval` argument of the `startPollingThread (..)` function.
Otherwise, there is no notion about the unit.