### PR TITLE
Improve CMake code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,31 +1,84 @@
 cmake_minimum_required(VERSION 3.15)
 
-project(fmtlog CXX)
+project(
+  fmtlog
+  LANGUAGES CXX
+  VERSION 2.2.2)
 
-if(MSVC)
-    add_compile_options(/std:c++latest)
+include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
+
+option(FMTLOG_USE_SYSTEM_FMT
+       "Use system fmt library instead of bundled one" OFF)
+
+if(FMTLOG_USE_SYSTEM_FMT)
+  find_package(fmt CONFIG REQUIRED)
 else()
-    add_compile_options(-Wall -O3 -std=c++17)
-    #add_compile_options(-Wall -Ofast -std=c++2a -DNDEBUG -march=skylake -flto -fno-exceptions -fno-rtti -fno-unwind-tables -fno-asynchronous-unwind-tables -DFMTLOG_NO_CHECK_LEVEL=1)
-    #SET(CMAKE_AR  "gcc-ar")
-    #SET(CMAKE_RANLIB  "gcc-ranlib")
-    link_libraries(pthread)
+  add_subdirectory(fmt)
+endif()
+find_package(Threads MODULE REQUIRED)
+
+# =================================================================================================
+
+add_library(${PROJECT_NAME}_flags INTERFACE)
+target_compile_features(${PROJECT_NAME}_flags INTERFACE cxx_std_17)
+target_link_libraries(${PROJECT_NAME}_flags INTERFACE Threads::Threads)
+
+if(NOT MSVC)
+  target_compile_options(${PROJECT_NAME}_flags INTERFACE -Wall $<$<CONFIG:Debug>:-O3>)
 endif()
 
-link_directories(.)
-include_directories(fmt/include)
+# =================================================================================================
 
-add_library(fmtlog-shared SHARED fmtlog.cc)
-if(MSVC)
-  target_link_libraries(fmtlog-shared fmt)
+add_library(${PROJECT_NAME}-shared SHARED fmtlog.cc)
+target_include_directories(${PROJECT_NAME}-shared
+                           INTERFACE $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+target_link_libraries(
+  ${PROJECT_NAME}-shared
+  PUBLIC fmt::fmt
+  PRIVATE ${PROJECT_NAME}_flags)
+
+add_library(${PROJECT_NAME}-static STATIC fmtlog.cc)
+target_include_directories(${PROJECT_NAME}-static
+                           INTERFACE $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+target_link_libraries(
+  ${PROJECT_NAME}-static
+  PUBLIC fmt::fmt
+  PRIVATE ${PROJECT_NAME}_flags)
+
+# =================================================================================================
+
+set(fmtlog_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/fmtlog")
+
+install(
+  TARGETS ${PROJECT_NAME}-shared ${PROJECT_NAME}-static ${PROJECT_NAME}_flags
+  EXPORT fmtlog_target
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(FILES ${CMAKE_SOURCE_DIR}/fmtlog.h ${CMAKE_SOURCE_DIR}/fmtlog-inl.h
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/fmtlog/)
+
+install(EXPORT fmtlog_target NAMESPACE fmtlog:: FILE fmtlogTargets.cmake
+        DESTINATION ${fmtlog_INSTALL_CMAKEDIR})
+
+configure_package_config_file(
+  ${CMAKE_CURRENT_LIST_DIR}/cmake/fmtlogConfig.cmake.in ${PROJECT_BINARY_DIR}/fmtlogConfig.cmake
+  INSTALL_DESTINATION ${fmtlog_INSTALL_CMAKEDIR})
+
+write_basic_package_version_file(${PROJECT_BINARY_DIR}/fmtlogConfigVersion.cmake
+                                 COMPATIBILITY SameMajorVersion)
+
+install(FILES ${PROJECT_BINARY_DIR}/fmtlogConfig.cmake
+              ${PROJECT_BINARY_DIR}/fmtlogConfigVersion.cmake
+        DESTINATION ${fmtlog_INSTALL_CMAKEDIR})
+
+# =================================================================================================
+
+option(BUILD_TESTING "Build tests" ON)
+
+if(BUILD_TESTING)
+  include(CTest)
+  enable_testing()
+  add_subdirectory(test)
 endif()
-install(TARGETS fmtlog-shared)
-
-add_library(fmtlog-static fmtlog.cc)
-if(MSVC)
-  target_link_libraries(fmtlog-static fmt)
-endif()
-install(TARGETS fmtlog-static)
-
-add_subdirectory(fmt)
-add_subdirectory(test)

--- a/cmake/fmtlogConfig.cmake.in
+++ b/cmake/fmtlogConfig.cmake.in
@@ -4,7 +4,9 @@ if(TARGET fmtlog::::fmtlog-static)
   return()
 endif()
 
-find_package(fmt CONFIG REQUIRED)
+if(@FMTLOG_USE_SYSTEM_FMT@)
+  find_package(fmt CONFIG REQUIRED)
+endif()
 find_package(Threads REQUIRED)
 
 include(${CMAKE_CURRENT_LIST_DIR}/fmtlogTargets.cmake)

--- a/cmake/fmtlogConfig.cmake.in
+++ b/cmake/fmtlogConfig.cmake.in
@@ -1,0 +1,14 @@
+@PACKAGE_INIT@
+
+if(TARGET fmtlog::::fmtlog-static)
+  return()
+endif()
+
+find_package(fmt CONFIG REQUIRED)
+find_package(Threads REQUIRED)
+
+include(${CMAKE_CURRENT_LIST_DIR}/fmtlogTargets.cmake)
+
+if(NOT TARGET fmtlog::fmtlog)
+  add_library(fmtlog::fmtlog ALIAS fmtlog::fmtlog-static)
+endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,6 @@
+cmake_minimum_required(VERSION 3.15)
+project(fmtlog_test LANGUAGES CXX)
+
 if(NOT MSVC)
   add_library(static_lib lib.cc)
 
@@ -5,50 +8,46 @@ if(NOT MSVC)
   target_compile_definitions(static_header_lib PUBLIC FMTLOG_HEADER_ONLY)
 
   add_library(shared_lib SHARED lib.cc)
-  install(TARGETS shared_lib)
 
   add_library(shared_header_lib SHARED lib.cc)
   target_compile_definitions(shared_header_lib PUBLIC FMTLOG_HEADER_ONLY)
-  install(TARGETS shared_header_lib)
 
   add_executable(link_static_static link_test.cc)
-  target_link_libraries(link_static_static fmtlog-static static_lib fmt)
-  install(TARGETS link_static_static)
+  target_link_libraries(link_static_static PRIVATE fmtlog-static static_lib)
+  add_test(NAME link_static_static COMMAND link_static_static)
 
   add_executable(link_static_shared link_test.cc)
-  target_link_libraries(link_static_shared fmtlog-static shared_lib fmt)
-  install(TARGETS link_static_shared)
+  target_link_libraries(link_static_shared PRIVATE fmtlog-static shared_lib)
+  add_test(NAME link_static_shared COMMAND link_static_shared)
 
   add_executable(link_shared_static link_test.cc)
-  target_link_libraries(link_shared_static fmtlog-shared static_lib fmt)
-  install(TARGETS link_shared_static)
+  target_link_libraries(link_shared_static PRIVATE fmtlog-shared static_lib)
+  add_test(NAME link_shared_static COMMAND link_shared_static)
 
   add_executable(link_shared_shared link_test.cc)
-  target_link_libraries(link_shared_shared fmtlog-shared shared_lib fmt)
-  install(TARGETS link_shared_shared)
+  target_link_libraries(link_shared_shared PRIVATE fmtlog-shared shared_lib)
+  add_test(NAME link_shared_shared COMMAND link_shared_shared)
 
   add_executable(link_header_static link_test.cc)
   target_link_libraries(link_header_static static_header_lib fmt)
-  install(TARGETS link_header_static)
+  add_test(NAME link_header_static COMMAND link_header_static)
 
   add_executable(link_header_shared link_test.cc)
   target_link_libraries(link_header_shared shared_header_lib fmt)
-  install(TARGETS link_header_shared)
-
+  add_test(NAME link_header_shared COMMAND link_header_shared)
 endif()
 
 add_executable(log_test log_test.cc)
-target_link_libraries(log_test fmtlog-static fmt)
+target_link_libraries(log_test PRIVATE fmtlog-static)
 #target_compile_definitions(log_test PUBLIC FMTLOG_HEADER_ONLY)
-install(TARGETS log_test)
+add_test(NAME log_test COMMAND log_test)
 
 add_executable(enc_dec_test enc_dec_test.cc)
-target_link_libraries(enc_dec_test fmtlog-static fmt)
-install(TARGETS enc_dec_test)
+target_link_libraries(enc_dec_test PRIVATE fmtlog-static)
+add_test(NAME enc_dec_test COMMAND enc_dec_test)
 
 add_executable(multithread_test multithread_test.cc)
-target_compile_definitions(multithread_test PUBLIC FMTLOG_HEADER_ONLY)
-#target_link_libraries(multithread_test fmtlog-static fmt)
-target_link_libraries(multithread_test fmt)
-install(TARGETS multithread_test)
+target_compile_definitions(multithread_test PUBLIC FMTLOG_HEADER_ONLY=1)
+target_link_libraries(multithread_test PRIVATE fmtlog-static)
+add_test(NAME multithread_test COMMAND multithread_test)
 


### PR DESCRIPTION
This PR modernises `fmtlog`'s CMake code:

- Allow building using a version of fmtlib found on the system (by default use the local version)
- Use `BUILD_TESTING` to control whether to enable or disable tests
- Properly install the project using a CMake installation config file
- Cleanup various other aspects