### PR TITLE
Add BUILD_TESTS_FMTLOG option to control building fmtlog tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,4 +28,7 @@ endif()
 install(TARGETS fmtlog-static)
 
 add_subdirectory(fmt)
-add_subdirectory(test)
+option(BUILD_TESTS_FMTLOG "Enable building tests" ON)
+if(BUILD_TESTS_FMTLOG)
+    add_subdirectory(test)
+endif()


### PR DESCRIPTION
- Introduced a CMake option BUILD_TESTS_FMTLOG (default ON) to enable or disable building the test directory for fmtlog.
- Wrapped add_subdirectory(test) inside a conditional based on BUILD_TESTS_FMTLOG.
- Allows users to configure the build with -DBUILD_TESTS_FMTLOG=OFF to skip tests.